### PR TITLE
YEL-391

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -313,8 +313,7 @@
   - name: Copy SSM Ingest files to ADT
     command: cp -R {{ item }}. /appdata/ADT/scripts
     with_items:
-      - /opt/dq-ssm_ingest/ADT/EXT_Server/
-      - /opt/dq-ssm_ingest/ADT/WEB_Server/
+      - /opt/dq-ssm_ingest/ADT/
 
   - name: Set permissions of /appdata/ADT/scripts to wherescape for log files
     file:


### PR DESCRIPTION
Change where SSM scripts are imported from.

Files in dq-ssm_ingest repo have been moved up from sub-directories to ADT parent directory.
This is because the sub-directories only made sense in Sungard where the scripts were deployed to two separate servers (EXT01 & WEB02).